### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-and-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/T4VN/uTPro/security/code-scanning/2](https://github.com/T4VN/uTPro/security/code-scanning/2)

The fix is to add an explicit `permissions` block to the workflow to control the scopes granted to the `GITHUB_TOKEN`. The recommended approach is to set the strictest permissions possible at the workflow or job level. In this case, most steps require only `contents: read`, but the release creation step requires `contents: write`. To follow the principle of least privilege, we will:

- Add a `permissions` block with `contents: write` at the job level (to ensure the release step can succeed).
- Alternatively, if we'd like even finer-grained security, we could set the global workflow scope to `contents: read` and override it for just the `build-and-release` job. However, since only one job exists, we will set it at the job level.
- Edit `.github/workflows/dotnet-release.yml`, adding:
   ```yaml
   permissions:
     contents: write
   ```
  directly under the job definition (i.e., as the first key under the `build-and-release` job).
- No changes to imports or other parts of code are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
