### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   copilot_review:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/T4VN/uTPro/security/code-scanning/9](https://github.com/T4VN/uTPro/security/code-scanning/9)

The best way to fix the problem is to explicitly specify the permissions needed for the workflow/job. Since the workflow appears to only interact with pull requests (presumably to comment or provide reviews via Copilot), the minimal permissions required would be `contents: read` and potentially `pull-requests: write` if writing to PRs is needed (e.g., commenting, reviewing). However, as a minimal and safe starting point per the CodeQL advice, adding `contents: read` at the job level (applies only to this job) is sufficient unless further write access is proven necessary. This involves editing the `.github/workflows/copilot-review.yml` file, adding a `permissions` block under the `copilot_review` job, above `runs-on`. No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
