### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout main repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/T4VN/uTPro/security/code-scanning/17](https://github.com/T4VN/uTPro/security/code-scanning/17)

In general, the fix is to add an explicit `permissions` block to the workflow or job so that the `GITHUB_TOKEN` has only the minimal scopes needed. This documents the intended privileges and avoids inheriting broader defaults from the repo or organization.

For this specific workflow, the `sync` job checks out the repo and pushes new commits back to it, so it needs `contents: write`. There is no evidence it needs other scopes (like `issues`, `pull-requests`, etc.). The least-privilege, non-breaking change is to add `permissions: contents: write` at the job level, directly under `runs-on: ubuntu-latest`. This keeps the existing behavior (push still works) while avoiding granting unnecessary additional permissions.

Concretely, in `.github/workflows/wiki-sync.yml`, modify the `sync` job definition (around line 11) to insert:

```yaml
    permissions:
      contents: write
```

immediately after `runs-on: ubuntu-latest`. No additional imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
