### PR TITLE
Potential fix for code scanning alert no. 25: URL redirection from remote source

### DIFF
--- a/uTPro/Foundation/uTPro.Foundation.Middleware/RequestLocalizationOptionMiddleware.cs
+++ b/uTPro/Foundation/uTPro.Foundation.Middleware/RequestLocalizationOptionMiddleware.cs
@@ -247,7 +247,15 @@ namespace uTPro.Foundation.Middleware
                     {
                         if (string.Equals(domainHost.Host, redirectUri.Host, StringComparison.OrdinalIgnoreCase))
                         {
-                            return _prefixUrl + httpContext.Request.Path + httpContext.Request.QueryString;
+                            var prefixPath = redirectUri.AbsolutePath ?? string.Empty;
+                            if (prefixPath.Contains("://", StringComparison.Ordinal))
+                                return string.Empty;
+
+                            prefixPath = "/" + prefixPath.Trim('/');
+                            if (prefixPath == "/")
+                                prefixPath = string.Empty;
+
+                            return prefixPath + httpContext.Request.Path + httpContext.Request.QueryString;
                         }
                     }
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/T4VN/uTPro/security/code-scanning/25](https://github.com/T4VN/uTPro/security/code-scanning/25)

To fix this safely, keep existing behavior (language/domain redirect) but ensure the redirect target is constructed as a **trusted local URL** and avoid passing a user-controlled absolute URL to `Redirect`.

Best approach in this file:
1. In `GetSchemeRedirect`, after verifying `prefixUrl` host is in allowed domains, build the redirect as a **relative local path** (`/{culturePrefix}{path}{query}`), not as absolute external URL text.
2. Reject malformed/unsafe prefix path segments (for example, anything containing `://`).
3. Return only local redirect strings so that line 90 redirects within the same application host.

This preserves functional intent (redirect to culture path and preserve query string) while removing open redirect risk from remote source URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
